### PR TITLE
Navigation geanedert - Speicher Button von "Submit" nach "Speichern" umbenannt

### DIFF
--- a/app/Resources/views/rooms/room_details.html.twig
+++ b/app/Resources/views/rooms/room_details.html.twig
@@ -12,11 +12,10 @@
                 </div>
             {% endfor %}
         {% endfor %}
-        <a href="{{ app.request.headers.get('referer') }}" class="float-right btn btn-secondary">
-            <i class="fas fa-chevron-left"></i>
-            <span>Zurück</span>
+        <a href="{{ url('list_room')}}" class="float-right btn btn-success">
+            <i class="fas"></i>
+            <span>Räume anzeigen</span>
         </a>
-
         <h2>Raum {{ action }}</h2>
         {{ form_start(form) }}
            {{ form_widget(form) }}

--- a/src/AppBundle/Controller/RoomDetailsController.php
+++ b/src/AppBundle/Controller/RoomDetailsController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 class RoomDetailsController extends Controller
 {
     /**
-     * @Route("/addRoom", name="add_room")
+     * @Route("/add/Room", name="add_room")
      */
     public function addRoomAction(Request $request): Response
     {
@@ -39,7 +39,7 @@ class RoomDetailsController extends Controller
     }
 
     /**
-    * @Route("/editRoom/{id}", name="edit_room", requirements  = { "id" = "\d+" })
+    * @Route("/edit/Room/{id}", name="edit_room", requirements  = { "id" = "\d+" })
     */
     public function updateRoomAction(Request $request, string $id): Response
     {
@@ -74,7 +74,7 @@ class RoomDetailsController extends Controller
             ->add('notiz', TextareaType::class, [
                 'required' => false
             ])
-            ->add('submit', SubmitType::class, [
+            ->add('Speichern', SubmitType::class, [
                 'attr' => [
                     'class' => 'btn btn-success'
                 ]


### PR DESCRIPTION
Navigation von Detailansicht der Räume geändert.
Vorher über "referer" auf die vorherige Seite. Nun Feste Route auf Liste Räume

Speicher Button in Detailansicht der Räume von "submit" nach "Speichern" umbenannt