### PR TITLE
Suchmodus "loose" nur noch bei bezeichnung

### DIFF
--- a/src/AppBundle/Controller/LieferantListController.php
+++ b/src/AppBundle/Controller/LieferantListController.php
@@ -9,8 +9,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-use AppBundle\Service\KomponentenSucheService;
-use AppBundle\Enum\KomponentenSuche as Suche;
 
 class LieferantListController extends Controller
 {
@@ -20,6 +18,7 @@ class LieferantListController extends Controller
      */
     public function showLieferantAction(Request $request): Response
     {
+
         $lieferantHeader = [];
         $lieferant = $this->getAllLieferanten();
         if (!empty($lieferant)) {

--- a/src/AppBundle/Service/KomponentenSucheService.php
+++ b/src/AppBundle/Service/KomponentenSucheService.php
@@ -20,8 +20,6 @@ class KomponentenSucheService
         $this->em = $entityManager;
     }
 
-
-
     /**
      * @Return Komponenten[]
      */
@@ -49,26 +47,12 @@ class KomponentenSucheService
 
         if ($raum_nr != null) {
             $qb->setParameter('raum', $raum_nr);
-            switch($mode) {
-                case Suche::loose:
-                    $qb->andWhere('REGEXP(IDENTITY(k.raeume_id), :raum) = 1');
-                    break;
-                case Suche::exact:
-                    $qb->andWhere('k.raeume_id = :raum');
-                    break;
-            }
+            $qb->andWhere('k.raeume_id = :raum');
         }
         
         if ($komp_art != null) {
             $qb->setParameter('komp_art', $komp_art);
-            switch($mode) {
-                case Suche::loose:
-                    $qb->andWhere('REGEXP(IDENTITY(k.komponentenarten_id), :komp_art) = 1');
-                    break;
-                case Suche::exact:
-                    $qb->andWhere('k.komponentenarten_id = :komp_art');
-                    break;
-            }
+            $qb->andWhere('k.komponentenarten_id = :komp_art');
         }
         return $qb->getQuery()->getArrayResult();
     }


### PR DESCRIPTION
Bei Suche nach Bezeichnung, Raum- & Komponentenart-Nummer nicht "loose" Suchen sondern immer "Exakt". Es macht keinen Sinn bei Eingabe der Raum-Nr "2" den Raum "20" zu finden. Der Parameter loose ist nur noch für die bezeichnung gültig